### PR TITLE
Include stdout and stderr of tests into Gradle output

### DIFF
--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -18,4 +18,7 @@ test {
     useJUnitPlatform {
         includeEngines 'spek2'
     }
+    testLogging {
+        showStandardStreams = true
+    }
 }


### PR DESCRIPTION
AFAICT, JUnit Platform integration with Gradle silently skips all the tests if it some misconfiguration or environment issue takes place (for example, see #1; I observed similar problem on my side -- successful build with 0 tests on `./gradlew check` -- when tried to place tests in default unnamed package). Stderr contains stacktrace though, so it may help during investigation.

This PR configures Gradle so that it dumps stdout and stderr of tests into Gradle output.